### PR TITLE
refactor: restructure login tests for improved organization and clarity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,31 @@ npx playwright test
 ### Running a Specific Test
 
 ```bash
-npx playwright test path/to/test.spec.ts
+npx playwright test path/to/test.spec.js
+```
+
+### Only run smoke tests
+
+```bash
+npx playwright test --grep '@smoke'
+```
+
+### Only run regression
+
+```bash
+npx playwright test --grep '@regression'
+```
+
+### Only run specific functional area
+
+```bash
+npx playwright test --grep '@login'
+```
+
+### Only run specific functional area + filter by sub-suite
+
+```bash
+npx playwright test --grep '(?=.*@login)(?=.*@smoke)'
 ```
 
 ### Generating a Test Report

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -1,16 +1,32 @@
 require('dotenv').config();
 const { test, expect } = require('@playwright/test');
 
-test('user is able to login', async ({ page }) => {
-  const baseURL = process.env.BASE_URL;
-  await page.goto(baseURL + '/login');
-  await expect(page).toHaveTitle(/The Internet/);
-  const root = page.locator('#content');
-  await expect(root.locator('h2')).toHaveText('Login Page');
-  const loginForm = root.locator('#login');
-  await expect(loginForm).toBeVisible();
-  await loginForm.locator('#username').fill('tomsmith');
-  await loginForm.locator('#password').fill('SuperSecretPassword!');
-  await loginForm.locator('button[type="submit"]').click();
-  await expect(page).toHaveURL(baseURL + '/secure');
+test.describe('Login flow', () => {
+  let baseURL;
+  let root;
+
+  test.beforeEach(async ({ page }) => {
+    testInfo.annotations.push({ type: 'tag', description: 'login' });
+
+    baseURL = process.env.BASE_URL;
+    await page.goto(`${baseURL}/login`);
+    root = page.locator('#content');
+    await expect(root.locator('h2')).toHaveText('Login Page');
+  });
+
+  test('login form is visible @login @smoke', async ({ page }, testInfo) => {
+    testInfo.annotations.push({ type: 'tag', description: 'smoke' });
+
+    await expect(root.locator('#login')).toBeVisible();
+  });
+
+  test('user can log in with valid credentials @login @regression', async ({ page }, testInfo) => {
+    testInfo.annotations.push({ type: 'tag', description: 'regression' });
+
+    const loginForm = root.locator('#login');
+    await loginForm.locator('#username').fill('tomsmith');
+    await loginForm.locator('#password').fill('SuperSecretPassword!');
+    await loginForm.locator('button[type="submit"]').click();
+    await expect(page).toHaveURL(`${baseURL}/secure`);
+  });
 });

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -5,7 +5,7 @@ test.describe('Login flow', () => {
   let baseURL;
   let root;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
     testInfo.annotations.push({ type: 'tag', description: 'login' });
 
     baseURL = process.env.BASE_URL;

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -6,7 +6,7 @@ test.describe('Login flow', () => {
   let root;
 
   test.beforeEach(async ({ page }, testInfo) => {
-    testInfo.annotations.push({ type: 'tag', description: 'login' });
+    testInfo.annotations.push({ type: 'area', description: 'login' });
 
     baseURL = process.env.BASE_URL;
     await page.goto(`${baseURL}/login`);
@@ -15,13 +15,13 @@ test.describe('Login flow', () => {
   });
 
   test('login form is visible @login @smoke', async ({ page }, testInfo) => {
-    testInfo.annotations.push({ type: 'tag', description: 'smoke' });
+    testInfo.annotations.push({ type: 'suite', description: 'smoke' });
 
     await expect(root.locator('#login')).toBeVisible();
   });
 
   test('user can log in with valid credentials @login @regression', async ({ page }, testInfo) => {
-    testInfo.annotations.push({ type: 'tag', description: 'regression' });
+    testInfo.annotations.push({ type: 'suite', description: 'regression' });
 
     const loginForm = root.locator('#login');
     await loginForm.locator('#username').fill('tomsmith');


### PR DESCRIPTION
## Feature: Refactor Test Login

## Description

- Context: login tests too big
- Main change: decomposed login tests into smoke and regression
- No link to ticket/story.

## Testing

1. Run tests
```bash
npx playwright test --grep '@smoke'
```
```bash
npx playwright test --grep '@regression'
```
```bash
npx playwright test --grep '@login'
```
```bash
npx playwright test --grep '(?=.*@login)(?=.*@smoke)'
```

2. Validate output

## Checklist

- [X] CI is passing
- [X] Documentation updated
- [X] Self-reviewed changes